### PR TITLE
Accept LSMB_VERSION build-arg & enable caching of initial git clone of repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,9 @@ RUN apt-get install -y \
     App::LedgerSMB::Admin
 
 # Install LedgerSMB
+ENV LSMB_REPO_UPSTREAM=https://github.com/ledgersmb/LedgerSMB.git
 RUN cd /srv && \
-  git clone https://github.com/ledgersmb/LedgerSMB.git ledgersmb
+  git clone $LSMB_REPO_UPSTREAM ledgersmb
 
 # Set LedgerSMB version (git tag/branch/commit)
 # Change LSMB_VERSION or use --build-arg on docker build commandline;
@@ -55,15 +56,17 @@ ARG CACHEBREAK
 ARG LSMB_VERSION=1.5.0-beta3
 ENV LSMB_VERSION ${LSMB_VERSION}
 
-# fetch changes to repo since possibly cached git clone above.
-# checkout specified tag/branch/commit (**NOTE above)
-# merge changes to current checked out branch
+# Set git remote source, eg: --build-arg LSMB_REPO=https://github.com/ehuelsmann/LedgerSMB.git 
+ARG LSMB_REPO=${LSMB_REPO_UPSTREAM}
 
 WORKDIR /srv/ledgersmb
 
-RUN git fetch \
- && git checkout $LSMB_VERSION \
- && (git merge || echo "git merge failed - this is expected if [$LSMB_VERSION] isn't a branch")
+# add remote repo as alt
+# fetch alt (fetches differences between the initial git clone and current alt remote)
+# checkout specified tag/branch/commit from alt; no need for merge because it's detached
+RUN git remote add alt ${LSMB_REPO} \
+ && git fetch alt \
+ && git checkout alt/$LSMB_VERSION 
 
 #RUN sed -i \
 #  -e "s/short_open_tag = Off/short_open_tag = On/g" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,11 +56,11 @@ ARG CACHEBREAK
 ARG LSMB_VERSION=1.5.0-beta3
 ENV LSMB_VERSION ${LSMB_VERSION}
 
-WORKDIR /srv/ledgersmb
 # fetch changes to repo since possibly cached git clone above.
 # checkout specified tag/branch/commit (**NOTE above)
 # merge changes to current checked out branch
-RUN git fetch \
+RUN cd /srv/ledgersmb \ 
+ && git fetch \
  && git checkout $LSMB_VERSION \
  && git merge || echo "git merge failed - this is expected if [$LSMB_VERSION] isn't a branch"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ ENV LSMB_VERSION ${LSMB_VERSION}
 RUN cd /srv/ledgersmb \ 
  && git fetch \
  && git checkout $LSMB_VERSION \
- && git merge || echo "git merge failed - this is expected if [$LSMB_VERSION] isn't a branch"
+ && (git merge || echo "git merge failed - this is expected if [$LSMB_VERSION] isn't a branch")
 
 #RUN sed -i \
 #  -e "s/short_open_tag = Off/short_open_tag = On/g" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM        perl:5
 MAINTAINER  Freelock john@freelock.com
 
-ENV 
-
 # Install Perl, Tex, Starman, psql client, and all dependencies
 RUN DEBIAN_FRONTENT=noninteractive && \
   apt-get update && apt-get -y install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,15 @@ RUN apt-get install -y \
     PGObject::Type::DateTime \
     App::LedgerSMB::Admin
 
-# Build time variables
-ENV LSMB_VERSION 1.5.0-beta3
+# Set LedgerSMB version (git tag/branch/commit)
+# Change the following line or set arg on docker build commandline;
+# eg:
+# docker build --build-arg LSMB_VERSION=1.4.0 ./
+# docker build --build-arg LSMB_VERSION=1c00d61 ./
+ARG LSMB_VERSION=1.5.0-beta3
+ENV LSMB_VERSION ${LSMB_VERSION}
 
+# Install LedgerSMB
 RUN cd /srv && \
   git clone https://github.com/ledgersmb/LedgerSMB.git ledgersmb
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,10 @@ RUN apt-get install -y \
     PGObject::Type::DateTime \
     App::LedgerSMB::Admin
 
-WORKDIR /srv 
+# Install LedgerSMB
 
-RUN git clone https://github.com/ledgersmb/LedgerSMB.git ledgersmb
+RUN cd /srv && \
+  git clone https://github.com/ledgersmb/LedgerSMB.git ledgersmb
 
 # Set LedgerSMB version (git tag/branch/commit)
 # Change LSMB_VERSION or use --build-arg on docker build commandline;
@@ -58,8 +59,10 @@ ENV LSMB_VERSION ${LSMB_VERSION}
 # fetch changes to repo since possibly cached git clone above.
 # checkout specified tag/branch/commit (**NOTE above)
 # merge changes to current checked out branch
-RUN cd /srv/ledgersmb \ 
- && git fetch \
+
+WORKDIR /srv/ledgersmb
+
+RUN git fetch \
  && git checkout $LSMB_VERSION \
  && (git merge || echo "git merge failed - this is expected if [$LSMB_VERSION] isn't a branch")
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN git clone https://github.com/ledgersmb/LedgerSMB.git ledgersmb
 #       if that branch/tag has already been cached.
 #
 #       As a hack to reliably use a branch (eg, master), try the following:
-#        docker build --build-arg CACHEBREAK="$(date)" LSMB_VERSION=master ./
+#        docker build --build-arg CACHEBREAK="$(date)" --build-arg LSMB_VERSION=master ./
 ARG CACHEBREAK
 ARG LSMB_VERSION=1.5.0-beta3
 ENV LSMB_VERSION ${LSMB_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN git clone https://github.com/ledgersmb/LedgerSMB.git ledgersmb
 #       if that branch/tag has already been cached.
 #
 #       As a hack to reliably use a branch (eg, master), try the following:
-#        docker build --build-arg CACHEBREAK=$(date) LSMB_VERSION=master ./
+#        docker build --build-arg CACHEBREAK="$(date)" LSMB_VERSION=master ./
 ARG CACHEBREAK
 ARG LSMB_VERSION=1.5.0-beta3
 ENV LSMB_VERSION ${LSMB_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 FROM        perl:5
 MAINTAINER  Freelock john@freelock.com
 
-# Build time variables
-ENV LSMB_VERSION 1.5.0-beta3
-
-
 # Install Perl, Tex, Starman, psql client, and all dependencies
 RUN DEBIAN_FRONTENT=noninteractive && \
   apt-get update && apt-get -y install \
@@ -25,7 +21,23 @@ RUN DEBIAN_FRONTENT=noninteractive && \
   postgresql-client-9.4 \
   ssmtp
 
-# Install LedgerSMB
+# 1.5 requirements
+RUN apt-get install -y \
+    libpgobject-perl \
+    libpgobject-simple-perl \
+    libpgobject-simple-role-perl \
+    libpgobject-util-dbmethod-perl \
+    && cpanm -nq \
+    Carton \
+    PGObject::Type::BigFloat \
+    PGObject::Composite \
+    PGObject::Type::JSON \
+    PGObject::Type::Composite \
+    PGObject::Type::DateTime \
+    App::LedgerSMB::Admin
+
+# Build time variables
+ENV LSMB_VERSION 1.5.0-beta3
 
 RUN cd /srv && \
   git clone https://github.com/ledgersmb/LedgerSMB.git ledgersmb
@@ -57,25 +69,9 @@ ENV POSTGRES_HOST postgres
 COPY start.sh /usr/local/bin/start.sh
 COPY update_ssmtp.sh /usr/local/bin/update_ssmtp.sh
 
-
 RUN chown www-data /etc/ssmtp /etc/ssmtp/ssmtp.conf && \
   chmod +x /usr/local/bin/update_ssmtp.sh /usr/local/bin/start.sh && \
   mkdir -p /var/www
-
-# 1.5 requirements
-RUN apt-get install -y \
-    libpgobject-perl \
-    libpgobject-simple-perl \
-    libpgobject-simple-role-perl \
-    libpgobject-util-dbmethod-perl
-RUN  cpanm -nq \
-    Carton \
-    PGObject::Type::BigFloat \
-    PGObject::Composite \
-    PGObject::Type::JSON \
-    PGObject::Type::Composite \
-    PGObject::Type::DateTime \
-    App::LedgerSMB::Admin
 
 # Not sure why this is not set correctly, and also why
 # it gets overridden here -- moved to start.sh.

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,6 @@ RUN apt-get install -y \
     PGObject::Type::DateTime \
     App::LedgerSMB::Admin
 
-# Install LedgerSMB
 WORKDIR /srv 
 
 RUN git clone https://github.com/ledgersmb/LedgerSMB.git ledgersmb

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,21 +38,20 @@ RUN apt-get install -y \
 
 # Install LedgerSMB
 WORKDIR /srv 
-# update the following label to force docker to cache the latest git clone:
-LABEL lsmb_docker_git_clone_cachebreak=2016-01-28
+
 RUN git clone https://github.com/ledgersmb/LedgerSMB.git ledgersmb
 
 # Set LedgerSMB version (git tag/branch/commit)
-# Change the following line or set arg on docker build commandline;
+# Change LSMB_VERSION or use --build-arg on docker build commandline;
 # eg:
-# docker build --build-arg LSMB_VERSION=1.4.0 ./
-# docker build --build-arg LSMB_VERSION=1c00d61 ./
-# NOTE: if you use a branch name (or a reused tag name) instead of a commit checksum
+# docker build --build-arg LSMB_VERSION=1.5.0-beta3 .
+# docker build --build-arg LSMB_VERSION=1c00d61 .
+# NOTE: If you use a branch name (or a reused tag name) instead of a commit checksum
 #       then docker's caching will see nothing new and you'll end up with stale files
 #       if that branch/tag has already been cached.
 #
-#       As a hack to reliably use a branch (eg, master), try the following:
-#        docker build --build-arg CACHEBREAK="$(date)" --build-arg LSMB_VERSION=master ./
+# As a hack to reliably update a branch (eg, master), --build-arg CACHEBREAK="$(date)":
+#  eg: docker build --build-arg CACHEBREAK="$(date)" --build-arg LSMB_VERSION=master .
 ARG CACHEBREAK
 ARG LSMB_VERSION=1.5.0-beta3
 ENV LSMB_VERSION ${LSMB_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,6 @@ RUN apt-get install -y \
     App::LedgerSMB::Admin
 
 # Install LedgerSMB
-
-# Install LedgerSMB
 RUN cd /srv && \
   git clone https://github.com/ledgersmb/LedgerSMB.git ledgersmb
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ WORKDIR /srv/ledgersmb
 # checkout specified tag/branch/commit (**NOTE above)
 # merge changes to current checked out branch
 RUN git fetch \
- && git checkout $LSMB_VERSION
+ && git checkout $LSMB_VERSION \
  && git merge || echo "git merge failed - this is expected if [$LSMB_VERSION] isn't a branch"
 
 #RUN sed -i \


### PR DESCRIPTION
These changes (along with the reordering of package installation in my previous pull request) make it quicker to test new revisions of LedgerSMB.

There's a couple of hacks to account for shortcomings in docker's caching methods, but in short it means you can build a new docker image with the latest master (or any other branch/tag/commit) from git in about 7 seconds with:
$ docker build --build-arg CACHEBREAK="$(date)" --build-arg LSMB_VERSION=master -t lsmb:master ./

I haven't yet tested what happens when there are changes in a branch to be merged, but it should work.

Sorry if my branches and pull requests are a mess - I'm still getting the hang of git/github.
