### PR TITLE
Add missing `apt upgrade`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ MAINTAINER  Freelock john@freelock.com
 # we're skipping, normally
 RUN echo "APT::Install-Recommends \"false\";\nAPT::Install-Suggests \"false\";" > /etc/apt/apt.conf.d/00recommends && \
   DEBIAN_FRONTEND="noninteractive" apt-get -y update && \
+  DEBIAN_FRONTEND="noninteractive" apt-get -y upgrade && \
   DEBIAN_FRONTEND="noninteractive" apt-get -y install \
   libcgi-emulate-psgi-perl libcgi-simple-perl libconfig-inifiles-perl \
   libdbd-pg-perl libdbi-perl libdatetime-perl \


### PR DESCRIPTION
This is needed to mitigate issues (eg: version dependency mismatches) due to out of date packages.
In theory this should be handled by the parent container, but that won't always be true