### PR TITLE
1.5 slim enhancement latest pg tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM        debian:jessie-slim
 MAINTAINER  Freelock john@freelock.com
 
 # Build time variables
-ENV LSMB_VERSION 1.5.15
+ENV LSMB_VERSION 1.5.16
 
 
 # Install Perl, Tex, Starman, psql client, and all dependencies


### PR DESCRIPTION
This is required to handle cases where the PG server is running a newer version than this container has available.
Failing to do this update will normally cause odd problems, including silent failure to backup.
Instead of the expected backup an empty file is generated.