### PR TITLE
Adjust plackup arguments for includes

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -32,4 +32,5 @@ fi
 # starman instance (instead of just the worker, which will immediately
 # get restarted); it also has a positive effect on memory use
 
-exec starman --port 5762 --workers ${LSMB_WORKERS:-5} --preload-app bin/ledgersmb-server.psgi
+exec starman --port 5762 --workers ${LSMB_WORKERS:-5} -I lib -I old/lib \
+             --preload-app bin/ledgersmb-server.psgi


### PR DESCRIPTION
Put `lib` and `old/lib` on starman command line, like we do on systemd, to remove the need for the application to know the directory structure.