### PR TITLE
Fix syntax error in base image start.sh

### DIFF
--- a/base/start.sh
+++ b/base/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 home_dir="$(dirname $(readlink -f $BASH_SOURCE))"
-"$home_dir/config.sh" || { echo "Failed configuration" ; exit 1 }
+"$home_dir/config.sh" || { echo "Failed configuration" ; exit 1; }
 
 LSMB_CONFIG_FILE="${LSMB_CONFIG_FILE:-/srv/ledgersmb/local/conf/ledgersmb.yaml}"
 export LSMB_CONFIG_FILE


### PR DESCRIPTION
Trying to run the base image gives the following error:

```
/usr/local/bin/start.sh: line 13: syntax error: unexpected end of file
```

The change proposed causes the script to no longer fail on parsing.